### PR TITLE
Added configuration to allow adding fields from source data to the sitemap

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Nickpeirson\Sculpin\Bundle\SitemapBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder;
+
+        $rootNode = $treeBuilder->root('sculpin_sitemap');
+        $rootNode
+            ->children()
+                ->arrayNode('source_data_fields')
+                    ->scalarPrototype()->end()
+                ->end()
+            ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/DependencyInjection/SculpinSitemapExtension.php
+++ b/DependencyInjection/SculpinSitemapExtension.php
@@ -13,7 +13,12 @@ class SculpinSitemapExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
+        $configuration = new Configuration;
+        $config = $this->processConfiguration($configuration, $configs);
+
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        $container->setParameter('sculpin_sitemap.source_data_fields', $config['source_data_fields']);
     }
 }

--- a/README.md
+++ b/README.md
@@ -93,13 +93,20 @@ It's also worth being aware that the `sitemap` data is keyed by the `loc` field,
     {% endfor %}
     </urlset>
 
+### Add existing source data
+It's possible to use existing source data by adding the following configuration to `sculpin_kernel.yml`, demonstrated below by mapping the title:
+```yaml
+sculpin_sitemap:
+  source_data_fields: [ 'title' ]
+```
+Now you can use `url.title` in your template.
+
 ## Contributing
 
 PRs greatfully recieved
 
 ## Roadmap
 
-* Add configuration to allow adding fields from source data to the sitemap. This would allow for reuse of existing data rather than needing to be duplicated in the source's `sitemap` data, e.g. title.
 * Further to using existing source data, allow mapping from source data to `sitemap`. This would allow for overriding sitemap fields with existing data, e.g. mapping `page.canonical_url`  override `url` for entries in `data.sitemap`.
 
 ## License

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,9 +5,9 @@
 
     <services>
         <service id="sculpin_sitemap.event.sitemap_generator" class="Nickpeirson\Sculpin\Bundle\SitemapBundle\SitemapGenerator">
+            <argument>%sculpin_sitemap.source_data_fields%</argument>
             <tag name="kernel.event_subscriber" />
             <tag name="sculpin.data_provider" alias="sitemap" />
         </service>
     </services>
-
 </container>

--- a/SitemapGenerator.php
+++ b/SitemapGenerator.php
@@ -18,6 +18,13 @@ class SitemapGenerator implements DataProviderInterface, EventSubscriberInterfac
     protected $sitemap;
     /** @var  SourceSet */
     protected $sources;
+    /** @var array */
+    protected $sourceDataFields;
+
+    public function __construct(array $fields = [])
+    {
+        $this->sourceDataFields = $fields;
+    }
 
     /**
      * {@inheritdoc}
@@ -71,6 +78,11 @@ class SitemapGenerator implements DataProviderInterface, EventSubscriberInterfac
                 'loc' => $loc,
                 'lastmod' => $lastmod
             ];
+            foreach ($this->sourceDataFields as $field) {
+                if (isset($data[ $field ])) {
+                    $url[ $field ] = $data[ $field ];
+                }
+            }
             if (isset($data['sitemap'])) {
                 $url = array_merge($url, $data['sitemap']);
             }


### PR DESCRIPTION
This is something we're using in our sitemap(.html) page in order to automate our human readable sitemap. Feeding back as it is backwards compatible and works for us, might be useful to other users too.